### PR TITLE
Add edit module name functionality

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,4 +13,5 @@ public class Messages {
     public static final String MESSAGE_MODULE_NAME_NOT_FOUND = "The module %1$s is not found";
     public static final String MESSAGE_FIND_STUDENT_SUCCESS = "Student %1$s is found!";
     public static final String MESSAGE_EDIT_STUDENT_SUCCESS = "Student %1$s is edited!";
+    public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Module %1$s is edited!";
 }

--- a/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
@@ -75,7 +75,7 @@ public class AddStudentCommand extends AddCommand {
                 return new CommandResult(String.format(MESSAGE_ADD_STUDENT_SUCCESS, studentToAdd));
             }
         }
-        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.moduleName));
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -46,13 +46,13 @@ public class DeleteModuleCommand extends DeleteCommand {
         for (Module module : lastShownList) {
             if (module.getName().equals(moduleName)) {
                 moduleToDelete = module;
-                logger.log(Level.INFO, "deleting module: " + moduleToDelete.getName().moduleName);
+                logger.log(Level.INFO, "deleting module: " + moduleToDelete.getName().getModuleName());
                 model.deleteModule(moduleToDelete);
                 return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, moduleToDelete));
             }
             ;
         }
-        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.moduleName));
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteStudentCommand.java
@@ -53,7 +53,7 @@ public class DeleteStudentCommand extends DeleteCommand {
                 return deleteStudentFromModule(module);
             }
         }
-        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.moduleName));
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
@@ -1,0 +1,158 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleName;
+
+/**
+ * Edits the module's name
+ */
+public class EditModuleCommand extends EditCommand {
+
+    public static final String COMMAND_WORD = "edit module";
+
+    public static final String MESSAGE_NOT_EDITED = "Both old module name and new module name must be provided";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits a module's name. Must provide "
+            + "old module name and the new module name "
+            + "Parameters: "
+            + PREFIX_MODULE_NAME + "OLD MODULE NAME "
+            + PREFIX_NAME + "NEW MODULE NAME "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_MODULE_NAME + "CS2103 "
+            + PREFIX_NAME + "CS2105 ";
+
+    private EditModuleCommand.EditModuleDescriptor editModuleDescriptor;
+    private ModuleName moduleName;
+
+    /**
+     * Creates an EditModuleCommand to edit the specified {@code Module}
+     *
+     * @param moduleName The name of the module to edit.
+     * @param editModuleDescriptor The edited module descriptor.
+     */
+    public EditModuleCommand(ModuleName moduleName, EditModuleCommand.EditModuleDescriptor editModuleDescriptor) {
+        requireNonNull(editModuleDescriptor);
+        requireNonNull(moduleName);
+        this.editModuleDescriptor = editModuleDescriptor;
+        this.moduleName = moduleName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Module> lastShownList = model.getFilteredModuleList();
+        for (Module module : lastShownList) {
+            if (module.getName().equals(moduleName)) {
+                return editModuleInformation(model, module);
+            }
+        }
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
+    }
+
+    /**
+     * Edits a module's information from TAB
+     * Error checking for module not found is handled by {@code this.execute()}
+     *
+     * @param module The module to be edited
+     * @param model The TAB model that stores the list of modules
+     * @return Statement indicating that the edition is successful.
+     */
+    public CommandResult editModuleInformation(Model model, Module module) {
+        Module editedModule = createEditedModule(module, editModuleDescriptor);
+        model.deleteModule(module);
+        model.addModule(editedModule);
+        return new CommandResult(String.format(Messages.MESSAGE_EDIT_MODULE_SUCCESS,
+                module.getName().getModuleName()));
+    }
+
+    private static Module createEditedModule(Module moduleToEdit,
+                                              EditModuleCommand.EditModuleDescriptor editModuleDescriptor) {
+        assert moduleToEdit != null;
+
+        ModuleName updatedName = editModuleDescriptor.getModuleName().orElse(moduleToEdit.getName());
+
+        return new Module(updatedName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditModuleCommand)) {
+            return false;
+        }
+
+        // state check
+        EditModuleCommand e = (EditModuleCommand) other;
+        return moduleName.equals(e.moduleName)
+                && editModuleDescriptor.equals(e.editModuleDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the module with. Each non-empty field value will replace the
+     * corresponding field value of the student.
+     */
+    public static class EditModuleDescriptor {
+        private ModuleName name;
+
+        public EditModuleDescriptor() {}
+
+        /**
+         * Copy constructor.
+         *
+         * @param  toCopy The edit student descriptor to be copied.
+         */
+        public EditModuleDescriptor(EditModuleCommand.EditModuleDescriptor toCopy) {
+            setModuleName(toCopy.name);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name);
+        }
+
+        public void setModuleName(ModuleName name) {
+            this.name = name;
+        }
+
+        public Optional<ModuleName> getModuleName() {
+            return Optional.ofNullable(name);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditModuleCommand.EditModuleDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditModuleCommand.EditModuleDescriptor e = (EditModuleCommand.EditModuleDescriptor) other;
+
+            return getModuleName().equals(e.getModuleName());
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStudentCommand.java
@@ -73,14 +73,14 @@ public class EditStudentCommand extends EditCommand {
                 return editStudentInformation(module);
             }
         }
-        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.moduleName));
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
     }
 
     /**
-     * Edits a student's information. the student from the specified module.
+     * Edits a student's information from the specified module.
      *
-     * @param module The module the student will be deleted from.
-     * @return Statement indicating that the deletion is successful.
+     * @param module The module the student will be edited from.
+     * @return Statement indicating that the edition is successful.
      * @throws CommandException Exception thrown when student is not found.
      */
     public CommandResult editStudentInformation(Module module) throws CommandException {
@@ -98,21 +98,21 @@ public class EditStudentCommand extends EditCommand {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Student} with the details of {@code studentToEdit}
+     * edited with {@code editStudentDescriptor}.
      *
      * @param studentToEdit The student to be edited.
-     * @param editPersonDescriptor The edited student descriptions.
+     * @param editStudentDescriptor The edited student descriptions.
      * @return The edited student.
      */
-    private static Student createEditedStudent(Student studentToEdit, EditStudentDescriptor editPersonDescriptor) {
+    private static Student createEditedStudent(Student studentToEdit, EditStudentDescriptor editStudentDescriptor) {
         assert studentToEdit != null;
 
-        Name updatedName = editPersonDescriptor.getName().orElse(studentToEdit.getName());
-        TeleHandle updatedTeleHandle = editPersonDescriptor.getTeleHandle().orElse(studentToEdit.getTeleHandle());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(studentToEdit.getEmail());
-        StudentId updatedStudentId = editPersonDescriptor.getStudentId().orElse(studentToEdit.getStudentId());
-        UniqueTaskList uniqueTaskList = editPersonDescriptor.uniqueTaskList;
+        Name updatedName = editStudentDescriptor.getName().orElse(studentToEdit.getName());
+        TeleHandle updatedTeleHandle = editStudentDescriptor.getTeleHandle().orElse(studentToEdit.getTeleHandle());
+        Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
+        StudentId updatedStudentId = editStudentDescriptor.getStudentId().orElse(studentToEdit.getStudentId());
+        UniqueTaskList uniqueTaskList = editStudentDescriptor.uniqueTaskList;
 
         Student editedStudent = new Student(updatedStudentId, updatedName, updatedTeleHandle, updatedEmail);
         editedStudent.setTaskList(uniqueTaskList);

--- a/src/main/java/seedu/address/logic/commands/FindStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindStudentCommand.java
@@ -55,7 +55,7 @@ public class FindStudentCommand extends Command {
 
         for (Module module : lastShownList) {
             if (module.getName().equals(moduleName)) {
-                String[] moduleNameKeywords = new String[]{moduleName.moduleName};
+                String[] moduleNameKeywords = new String[]{moduleName.getModuleName()};
                 ModuleNameEqualsKeywordsPredicate predicate =
                         new ModuleNameEqualsKeywordsPredicate(Arrays.asList(moduleNameKeywords));
                 model.updateFilteredModuleList(predicate);
@@ -63,7 +63,7 @@ public class FindStudentCommand extends Command {
                 return new CommandResult(String.format(MESSAGE_FIND_STUDENT_SUCCESS, studentId));
             }
         }
-        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.moduleName));
+        throw new CommandException(String.format(Messages.MESSAGE_MODULE_NAME_NOT_FOUND, moduleName.getModuleName()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditModuleCommand;
 import seedu.address.logic.commands.EditStudentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -35,8 +36,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         final String commandWord = "edit " + matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
-        //            case EditModuleCommand.COMMAND_WORD:
-        //                return new EditModuleCommandParser().parse(arguments);
+        case EditModuleCommand.COMMAND_WORD:
+            return new EditModuleCommandParser().parse(arguments);
         //            case EditTaskCommand.COMMAND_WORD:
         //                return new EditTaskCommandParser().parse(arguments); //to be implemented
         case EditStudentCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/EditModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditModuleCommandParser.java
@@ -1,4 +1,46 @@
 package seedu.address.logic.parser;
 
-public class EditModuleCommandParser {
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.EditModuleCommand;
+import seedu.address.logic.commands.EditModuleCommand.EditModuleDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleName;
+
+public class EditModuleCommandParser implements Parser<EditModuleCommand> {
+
+    @Override
+    public EditModuleCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE_NAME, PREFIX_NAME);
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULE_NAME, PREFIX_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditModuleCommand.MESSAGE_USAGE));
+        }
+
+        ModuleName moduleName = ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_MODULE_NAME).get());
+
+        EditModuleDescriptor editModuleDescriptor = new EditModuleDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editModuleDescriptor.setModuleName(ParserUtil.parseModuleName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (!editModuleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditModuleCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditModuleCommand(moduleName, editModuleDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/model/module/ModuleName.java
+++ b/src/main/java/seedu/address/model/module/ModuleName.java
@@ -18,7 +18,7 @@ public class ModuleName {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public final String moduleName;
+    private final String moduleName;
 
     /**
      * Constructs a {@code Name}.
@@ -36,6 +36,10 @@ public class ModuleName {
      */
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public String getModuleName() {
+        return this.moduleName;
     }
 
 

--- a/src/main/java/seedu/address/model/module/ModuleNameEqualsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleNameEqualsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class ModuleNameEqualsKeywordsPredicate implements Predicate<Module> {
     @Override
     public boolean test(Module module) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.getName().moduleName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.getName().getModuleName(), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/ModuleCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCard.java
@@ -46,7 +46,7 @@ public class ModuleCard extends UiPart<Region> {
     public ModuleCard(Module module, int displayedIndex) {
         super(FXML);
         this.module = module;
-        name.setText(module.getName().moduleName);
+        name.setText(module.getName().getModuleName());
     }
 
     /**


### PR DESCRIPTION
Fix #83
Add edit module name functionality
I would also like input on the following issue:
I used the prefix `n/` (normally used for student name) as the prefix to parse the name for the new module, so the command format is `edit module m/CS2103 n/CS2105`.
Do you guys think this is fine? Or should I create a new prefix just for this? Thanks :>