### PR TITLE
UI enhancement

### DIFF
--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -44,6 +44,7 @@ public class TaskCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         taskId.setText(task.getTaskId().value);
         taskName.setText(task.getTaskName().taskName);
+        taskName.setWrapText(true);
         taskDeadline.setText(task.getTaskDeadline().value);
         isComplete.setText(task.isComplete() ? "Completed" : "Incomplete");
     }

--- a/src/main/resources/view/TaskCardComplete.fxml
+++ b/src/main/resources/view/TaskCardComplete.fxml
@@ -18,17 +18,21 @@
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>
-            <HBox spacing="5" alignment="CENTER_LEFT">
+            <HBox spacing="5">
                 <Label fx:id="id" styleClass="cell_big_label">
                     <minWidth>
                         <!-- Ensures that the label text is never truncated -->
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="taskName" styleClass="task_default_big_label" text="\$taskName"/>
-                <Label fx:id="taskId" text="\$taskId" styleClass="task_default_small_label" />
-                <Label fx:id="taskDeadline" styleClass="task_default_small_label" text="\$taskDeadline" />
-                <Label fx:id="isComplete" styleClass="task_complete_small_label" text="\$isComplete" />
+                <VBox alignment="CENTER_LEFT">
+                    <Label fx:id="taskName" styleClass="task_default_big_label" text="\$taskName"/>
+                    <HBox spacing="5">
+                        <Label fx:id="taskId" text="\$taskId" styleClass="task_default_small_label" />
+                        <Label fx:id="taskDeadline" styleClass="task_default_small_label" text="\$taskDeadline" />
+                        <Label fx:id="isComplete" styleClass="task_complete_small_label" text="\$isComplete" />
+                    </HBox>
+                </VBox>
             </HBox>
         </VBox>
     </GridPane>

--- a/src/main/resources/view/TaskCardIncomplete.fxml
+++ b/src/main/resources/view/TaskCardIncomplete.fxml
@@ -18,17 +18,21 @@
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>
-            <HBox spacing="5" alignment="CENTER_LEFT">
+            <HBox spacing="5">
                 <Label fx:id="id" styleClass="cell_big_label">
                     <minWidth>
                         <!-- Ensures that the label text is never truncated -->
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="taskName" styleClass="task_default_big_label" text="\$taskName"/>
-                <Label fx:id="taskId" text="\$taskId" styleClass="task_default_small_label" />
-                <Label fx:id="taskDeadline" styleClass="task_default_small_label" text="\$taskDeadline" />
-                <Label fx:id="isComplete" styleClass="task_incomplete_small_label" text="\$isComplete" />
+                <VBox alignment="CENTER_LEFT">
+                    <Label fx:id="taskName" styleClass="task_default_big_label" text="\$taskName"/>
+                    <HBox spacing="5">
+                        <Label fx:id="taskId" text="\$taskId" styleClass="task_default_small_label" />
+                        <Label fx:id="taskDeadline" styleClass="task_default_small_label" text="\$taskDeadline" />
+                        <Label fx:id="isComplete" styleClass="task_incomplete_small_label" text="\$isComplete" />
+                    </HBox>
+                </VBox>
             </HBox>
         </VBox>
     </GridPane>

--- a/src/main/resources/view/TaskListPanel.fxml
+++ b/src/main/resources/view/TaskListPanel.fxml
@@ -3,4 +3,4 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<ListView fx:id="taskListView" VBox.vgrow="ALWAYS" prefHeight="50" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"/>
+<ListView fx:id="taskListView" VBox.vgrow="ALWAYS" prefHeight="100" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"/>


### PR DESCRIPTION
Fix #162 #170 

- Add text wrapper for task name
- task name and details will now be vertically placed so that the long task name will not affect the display of task id, ddl and status

![Screenshot 2021-11-01 132451](https://user-images.githubusercontent.com/69947227/139626242-0e56bafb-22a9-4875-85c6-7d2ab5749fd3.png)

