### PR TITLE
Revert website layout

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,7 +8,7 @@
     {%- include header.html -%}
 
     <main class="page-content" aria-label="Content">
-    <div  style="max-width:1000px; margin-left: 150px; margin-right: 150px;">
+    <div  class="wrapper">
       {{ content }}
     </div>
 


### PR DESCRIPTION
The changed website layout seems to affect the PDF conversion so changing it back to the original to avoid any extra potential issues.

The diagrams currently seem good enough with the original layout when I ran the website on the local server.